### PR TITLE
Fixing icon on hover issue. (#448)

### DIFF
--- a/js/artwork.js
+++ b/js/artwork.js
@@ -59,12 +59,12 @@ function showMaterialHighlight(x, y, r, event, scale, stage) {
         active: new createjs.Shape()
     };
 
-    circles.highlight.graphics.f(HIGHLIGHTCOLOR).drawCircle(0, 0, r);
+    circles.highlight.graphics.f(HIGHLIGHTCOLOR).drawCircle(-6, -6, r);
     circles.highlight.alpha = 0.3;
     circles.highlight.x = x;
     circles.highlight.y = y;
 
-    circles.active.graphics.f(ACTIVECOLOR).drawCircle(0, 0, r);
+    circles.active.graphics.f(ACTIVECOLOR).drawCircle(-6, -6, r);
     circles.active.alpha = 0;
 
     stage.addChild(circles.highlight, circles.active);


### PR DESCRIPTION
On hovering the icons at the top left corner the circle was not enclosing the
icons.

Changing the coordinates of the centre of the circle in artwork.js fixed the
issue.

Fixes https://github.com/sugarlabs/turtleblocksjs/issues/447